### PR TITLE
chore: better handling of errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,6 @@ pub enum NovuError {
     InvalidValues(String, String),
     #[error("couldn't find template '{0}'")]
     TemplateNotFound(String),
-    #[error("{0}")]
-    Unknown(String),
+    #[error("NovuError - UnexpectedResponse: {code:?} - {msg:?}")]
+    UnexpectedResponse { msg: String, code: String },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,23 +91,15 @@ impl Novu {
         let result = self.client.post("/events/trigger", Some(&data)).await?;
 
         match result {
-            client::Response::Success(data) => Ok(data.data),
-            client::Response::Error(err) => match err.status_code {
-                422 => Err(match err.message.as_str() {
-                    "TEMPLATE_NOT_FOUND" => NovuError::TemplateNotFound(data.name.to_string()),
-                    _ => NovuError::Unknown("".to_string()),
-                }),
-                401 => Err(NovuError::UnauthorizedError("/events/trigger".to_string())),
-                400 => {
-                    println!("{:?}", err);
-                    todo!()
-                }
-                code => todo!("{}", code),
-            },
-            client::Response::Messages(err) => Err(NovuError::InvalidValues(
-                "triggering".to_string(),
-                format!("{:?}", err.message),
-            )),
+            crate::client::Response::Success(data) => Ok(data.data),
+            crate::client::Response::Error(err) => Err(NovuError::UnexpectedResponse {
+                msg: err.message,
+                code: err.status_code.to_string(),
+            }),
+            crate::client::Response::Messages(err) => Err(NovuError::UnexpectedResponse {
+                msg: format!("{:?}", err.message),
+                code: err.status_code.to_string(),
+            }),
         }
     }
 

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -223,8 +223,14 @@ impl Subscribers {
 
         match result {
             crate::client::Response::Success(data) => Ok(data.data),
-            crate::client::Response::Error(err) => todo!("{:?}", err),
-            crate::client::Response::Messages(err) => todo!("{:?}", err),
+            crate::client::Response::Error(err) => Err(NovuError::UnexpectedResponse {
+                msg: err.message,
+                code: err.status_code.to_string(),
+            }),
+            crate::client::Response::Messages(err) => Err(NovuError::UnexpectedResponse {
+                msg: format!("{:?}", err.message),
+                code: err.status_code.to_string(),
+            }),
         }
     }
 
@@ -237,8 +243,14 @@ impl Subscribers {
 
         match result {
             crate::client::Response::Success(data) => Ok(data.data),
-            crate::client::Response::Error(err) => todo!("{:?}", err),
-            crate::client::Response::Messages(err) => todo!("{:?}", err),
+            crate::client::Response::Error(err) => Err(NovuError::UnexpectedResponse {
+                msg: err.message,
+                code: err.status_code.to_string(),
+            }),
+            crate::client::Response::Messages(err) => Err(NovuError::UnexpectedResponse {
+                msg: format!("{:?}", err.message),
+                code: err.status_code.to_string(),
+            }),
         }
     }
 
@@ -252,8 +264,14 @@ impl Subscribers {
 
         match result {
             crate::client::Response::Success(data) => Ok(data.data),
-            crate::client::Response::Error(err) => todo!("{:?}", err),
-            crate::client::Response::Messages(err) => todo!("{:?}", err),
+            crate::client::Response::Error(err) => Err(NovuError::UnexpectedResponse {
+                msg: err.message,
+                code: err.status_code.to_string(),
+            }),
+            crate::client::Response::Messages(err) => Err(NovuError::UnexpectedResponse {
+                msg: format!("{:?}", err.message),
+                code: err.status_code.to_string(),
+            }),
         }
     }
 
@@ -266,8 +284,14 @@ impl Subscribers {
 
         match result {
             crate::client::Response::Success(data) => Ok(data.data),
-            crate::client::Response::Error(err) => todo!("{:?}", err),
-            crate::client::Response::Messages(err) => todo!("{:?}", err),
+            crate::client::Response::Error(err) => Err(NovuError::UnexpectedResponse {
+                msg: err.message,
+                code: err.status_code.to_string(),
+            }),
+            crate::client::Response::Messages(err) => Err(NovuError::UnexpectedResponse {
+                msg: format!("{:?}", err.message),
+                code: err.status_code.to_string(),
+            }),
         }
     }
 
@@ -280,8 +304,14 @@ impl Subscribers {
         let result = self.client.put(endpoint, &data).await?;
         match result {
             crate::client::Response::Success(data) => Ok(data.data),
-            crate::client::Response::Error(err) => todo!("{:?}", err),
-            crate::client::Response::Messages(err) => todo!("{:?}", err),
+            crate::client::Response::Error(err) => Err(NovuError::UnexpectedResponse {
+                msg: err.message,
+                code: err.status_code.to_string(),
+            }),
+            crate::client::Response::Messages(err) => Err(NovuError::UnexpectedResponse {
+                msg: format!("{:?}", err.message),
+                code: err.status_code.to_string(),
+            }),
         }
     }
 }


### PR DESCRIPTION
Introduces ```UnknownResponse``` Error type that we use in stablesats-rs to handle the ```Response``` errors